### PR TITLE
Handle empty input in getProbabilities

### DIFF
--- a/LangDetector.php
+++ b/LangDetector.php
@@ -36,19 +36,25 @@ class LangDetector{
 		return strlen(trim($word))>0;
 	}
 
-	/**
-	 * Returns an associative array that map each language code to the probability that $text is of that language.
-	 */
+        /**
+         * Returns an associative array that map each language code to the probability that $text is of that language.
+         * If the input contains no valid words, all languages are returned with a probability of 0.
+         */
 	function getProbabilities($text){
 		$probs=Array();
 
-		$words = array_filter(explode(' ',str_replace($this->badChars,' ',$text)), array($this, 'filter'));
+                $words = array_filter(explode(' ',str_replace($this->badChars,' ',$text)), array($this, 'filter'));
 
-		$totalWords=count($words);
+                $totalWords=count($words);
 
-		foreach($this->langs as $lang){
-			$pspell = pspell_new($lang);
-			$goodWords=0;
+                // Return zero probabilities when there are no valid words
+                if ($totalWords === 0) {
+                        return array_fill_keys($this->langs, 0);
+                }
+
+                foreach($this->langs as $lang){
+                        $pspell = pspell_new($lang);
+                        $goodWords=0;
 			foreach($words as $word){
 				if(pspell_check($pspell, $word)){
 					$goodWords++;

--- a/README.md
+++ b/README.md
@@ -38,12 +38,15 @@ You may be interested in the probability of $text to be any of the languages.
 
 will return
 
-	Array
-	(
-		[it] => 1
-		[fr] => 0.45454545454545
-		[en] => 0.36363636363636
-	)
+        Array
+        (
+                [it] => 1
+                [fr] => 0.45454545454545
+                [en] => 0.36363636363636
+        )
+
+If the input text contains no valid words after filtering, `getProbabilities` returns
+zero for all languages.
 
 Finally, the input text is filtered in order to better detect the language.
 The filter will strip out all sort of characters allowing the library to detect the language of texts like the following.


### PR DESCRIPTION
## Summary
- return zero probabilities when there are no valid words
- document zero-probability behavior in `getProbabilities`

## Testing
- `php -l LangDetector.php` *(fails: `php` not installed)*