### PR TITLE
Update getLang doc comment

### DIFF
--- a/LangDetector.php
+++ b/LangDetector.php
@@ -61,9 +61,9 @@ class LangDetector{
 		return $probs;
 	}
 
-	/**
-	 * Returns the most probable language for the given $text if the probability is above a threshold (0.75 by default), false otherwhise.
-	 */
+        /**
+         * Returns the most probable language for the given $text if the probability is at or above a threshold (0.75 by default), false otherwhise.
+         */
 	function getLang($text){
 		$probs = $this->getProbabilities($text);
 		$lang = key($probs);


### PR DESCRIPTION
## Summary
- clarify the `getLang` PHPDoc to say "at or above a threshold" rather than "above a threshold"

## Testing
- `php -l LangDetector.php` *(fails: `php` not found)*